### PR TITLE
Stop user manager from falsely giving save warning

### DIFF
--- a/src/org/wildstang/wildrank/desktopv2/users/UserManagerPanel.java
+++ b/src/org/wildstang/wildrank/desktopv2/users/UserManagerPanel.java
@@ -185,7 +185,6 @@ public class UserManagerPanel extends JPanel implements ActionListener, TableMod
 				revision.save();
 			}
 
-			editedWithoutSaving = false;
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -197,6 +196,7 @@ public class UserManagerPanel extends JPanel implements ActionListener, TableMod
 			e.printStackTrace();
 		}
 		updateTable();
+		editedWithoutSaving = false;
 	}
 
 	// creates users and populates the window based on data from a csv file


### PR DESCRIPTION
Reloading the users and updating the table after a save triggered the change listener, which set our edited flag. We were resetting that flag in the wrong place. This fixes that.